### PR TITLE
Update paths, documentation, and versioning for main module integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mythofleader Go HTTP 서버
+# Go HTTP 서버
 
 Go를 위한 간단하고 추상화된 HTTP 서버 라이브러리로, Gin, 표준 net/http 및 AWS Lambda와 같은 인기 있는 프레임워크를 래핑합니다.
 

--- a/docs/middleware/AUTH_MIDDLEWARE.md
+++ b/docs/middleware/AUTH_MIDDLEWARE.md
@@ -19,11 +19,11 @@
 
 ```go
 type UserLookupInterface interface {
-// LookupUserByBasicAuth looks up a user by username and password
-LookupUserByBasicAuth(username, password string) (interface{}, error)
+    // LookupUserByBasicAuth looks up a user by username and password
+    LookupUserByBasicAuth(username, password string) (interface{}, error)
 
-// LookupUserByJWT looks up a user by JWT claims
-LookupUserByJWT(claims MapClaims) (interface{}, error)
+    // LookupUserByJWT looks up a user by JWT claims
+    LookupUserByJWT(claims MapClaims) (interface{}, error)
 }
 ```
 
@@ -76,9 +76,9 @@ return user, nil
 인증 미들웨어는 특정 경로에 대한 인증 검사를 건너뛸 수 있습니다. `SkipPaths` 필드에 건너뛸 경로 목록을 설정하여 해당 경로에 대한 인증 검사를 비활성화할 수 있습니다:
 
 ```go
-authConfig := &middleware.AuthConfig{
+authConfig := &server.AuthConfig{
 UserLookup: userService,
-AuthType:   middleware.AuthTypeJWT,
+AuthType:   server.AuthTypeJWT,
 JWTSecret:  "your-secret-key",
 SkipPaths: []string{
 "/health",
@@ -88,7 +88,7 @@ SkipPaths: []string{
 "/user/:id",      // 파라미터 패턴 - /user/123, /user/abc 등 모든 사용자 ID 경로
 },
 }
-s.Use(middleware.AuthMiddleware(authConfig))
+s.Use(server.AuthMiddleware(authConfig))
 ```
 
 이렇게 하면 다음 경로에 대한 요청은 인증 검사를 건너뛰게 됩니다:
@@ -159,9 +159,9 @@ s.Use(server.AuthMiddleware(authConfig))
 userService := NewUserService()
 
 // 기본 인증을 위한 인증 미들웨어 구성
-basicAuthConfig := &middleware.AuthConfig{
+basicAuthConfig := &server.AuthConfig{
 UserLookup: userService,
-AuthType:   middleware.AuthTypeBasic,
+AuthType:   server.AuthTypeBasic,
 
 // 선택 사항: 사용자 정의 오류 메시지
 UnauthorizedMessage: "Authentication required",
@@ -169,9 +169,9 @@ ForbiddenMessage:    "Access denied",
 }
 
 // 또는 JWT 인증을 위한 인증 미들웨어 구성
-jwtAuthConfig := &middleware.AuthConfig{
+jwtAuthConfig := &server.AuthConfig{
 UserLookup: userService,
-AuthType:   middleware.AuthTypeJWT,
+AuthType:   server.AuthTypeJWT,
 JWTSecret:  "your-secret-key",
 
 // 선택 사항: 사용자 정의 오류 메시지
@@ -181,14 +181,14 @@ ForbiddenMessage:    "Access denied",
 
 // 라우트 그룹에 미들웨어 추가
 protectedBasic := server.Group("/api/basic")
-protectedBasic.Use(middleware.AuthMiddleware(basicAuthConfig))
+protectedBasic.Use(server.AuthMiddleware(basicAuthConfig))
 
 protectedJWT := server.Group("/api/jwt")
-protectedJWT.Use(middleware.AuthMiddleware(jwtAuthConfig))
+protectedJWT.Use(server.AuthMiddleware(jwtAuthConfig))
 
 // 또는 특정 라우트에 추가
-server.GET("/protected-basic", middleware.AuthMiddleware(basicAuthConfig), handleProtectedRoute)
-server.GET("/protected-jwt", middleware.AuthMiddleware(jwtAuthConfig), handleProtectedRoute)
+server.GET("/protected-basic", server.AuthMiddleware(basicAuthConfig), handleProtectedRoute)
+server.GET("/protected-jwt", server.AuthMiddleware(jwtAuthConfig), handleProtectedRoute)
 ```
 
 ### 3. 인증된 사용자 접근하기
@@ -196,9 +196,9 @@ server.GET("/protected-jwt", middleware.AuthMiddleware(jwtAuthConfig), handlePro
 라우트 핸들러에서 요청 컨텍스트에서 인증된 사용자에 접근할 수 있습니다:
 
 ```go
-func handleProtectedRoute(c core.Context) {
+func handleProtectedRoute(c server.Context) {
 // 컨텍스트에서 인증된 사용자 가져오기
-user, ok := middleware.GetUserFromContext(c.Request().Context())
+user, ok := server.GetUserFromContext(c.Request().Context())
 if !ok {
 c.JSON(http.StatusUnauthorized, map[string]string{"error": "Unauthorized"})
 return

--- a/docs/middleware/ERROR_HANDLER_MIDDLEWARE.md
+++ b/docs/middleware/ERROR_HANDLER_MIDDLEWARE.md
@@ -11,7 +11,7 @@ package main
 
 import (
     "fmt"
-    server "github.com/tenqube/tenqube-go-http-server"
+    server "github.com/mythofleader/go-http-server"
 )
 
 func main() {
@@ -112,7 +112,7 @@ s.Use(errorHandlerMiddleware.Middleware(nil))
 errorHandlerMiddleware := s.GetErrorHandlerMiddleware()
 
 // 기본 구성으로 미들웨어 추가
-s.Use(errorHandlerMiddleware.Middleware(middleware.DefaultErrorHandlerConfig()))
+s.Use(errorHandlerMiddleware.Middleware(server.DefaultErrorHandlerConfig()))
 ```
 
 기본 구성은 다음과 같은 값을 사용합니다:

--- a/docs/middleware/LOGGING_MIDDLEWARE.md
+++ b/docs/middleware/LOGGING_MIDDLEWARE.md
@@ -10,7 +10,7 @@
 package main
 
 import (
-	server "github.com/tenqube/tenqube-go-http-server"
+	server "github.com/mythofleader/go-http-server"
 )
 
 func main() {
@@ -159,7 +159,7 @@ s.Use(loggingMiddleware.Middleware(nil))
 loggingMiddleware := s.GetLoggingMiddleware()
 
 // 기본 구성으로 미들웨어 추가
-s.Use(loggingMiddleware.Middleware(middleware.DefaultLoggingConfig()))
+s.Use(loggingMiddleware.Middleware(server.DefaultLoggingConfig()))
 ```
 
 기본 구성은 다음과 같은 값을 사용합니다:

--- a/examples/auth/test.sh
+++ b/examples/auth/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Build the example
-go build -o auth_example
+go build -o auth_example main.go
 
 # Start the server in the background
 ./auth_example &
@@ -22,14 +22,14 @@ curl -v -H "Authorization: Basic $(echo -n 'user1:password' | base64)" http://lo
 kill $SERVER_PID
 
 # Modify the example to use Basic authentication
-sed -i 's/AuthType:   server.AuthTypeJWT/AuthType:   server.AuthTypeBasic/' auth_example.go
-sed -i 's/\/\/ basicAuthConfig/basicAuthConfig/' auth_example.go
-sed -i 's/\/\/     UserLookup/    UserLookup/' auth_example.go
-sed -i 's/\/\/     AuthType/    AuthType/' auth_example.go
-sed -i 's/server.AuthMiddleware(authConfig)/server.AuthMiddleware(basicAuthConfig)/' auth_example.go
+sed -i 's/AuthType:   server.AuthTypeJWT/AuthType:   server.AuthTypeBasic/' main.go
+sed -i 's/\/\/ basicAuthConfig/basicAuthConfig/' main.go
+sed -i 's/\/\/     UserLookup/    UserLookup/' main.go
+sed -i 's/\/\/     AuthType/    AuthType/' main.go
+sed -i 's/server.AuthMiddleware(authConfig)/server.AuthMiddleware(basicAuthConfig)/' main.go
 
 # Build the modified example
-go build -o auth_example_basic
+go build -o auth_example_basic main.go
 
 # Start the server in the background
 ./auth_example_basic &

--- a/examples/cors/test.sh
+++ b/examples/cors/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Build the example
-go build -o cors_example
+go build -o cors_example main.go
 
 # Start the server in the background
 ./cors_example &
@@ -31,12 +31,12 @@ kill $SERVER_PID
 
 # Now modify the example to use specific allowed domains
 echo -e "\n\nModifying the example to use specific allowed domains..."
-sed -i 's/\/\/ AllowedDomains: \[\]string{/AllowedDomains: []string{/' cors_example.go
-sed -i 's/\/\/     "http:\/\/localhost:3000",/    "http:\/\/localhost:3000",/' cors_example.go
-sed -i 's/\/\/     "https:\/\/example.com",/    "https:\/\/example.com",/' cors_example.go
+sed -i 's/\/\/ AllowedDomains: \[\]string{/AllowedDomains: []string{/' main.go
+sed -i 's/\/\/     "http:\/\/localhost:3000",/    "http:\/\/localhost:3000",/' main.go
+sed -i 's/\/\/     "https:\/\/example.com",/    "https:\/\/example.com",/' main.go
 
 # Build the modified example
-go build -o cors_example_restricted
+go build -o cors_example_restricted main.go
 
 # Start the server in the background
 ./cors_example_restricted &

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@
 package server
 
 // Version is the current version of the go-http-server.
-const Version = "0.0.3"
+const Version = "0.0.31"


### PR DESCRIPTION
- Updated scripts and examples to target `main.go` instead of old filenames.
- Synced package imports across documentation to align with the new module path `github.com/mythofleader/go-http-server`.
- Adjusted README and middleware examples to reflect accurate usage and naming conventions.
- Incremented version from `0.0.3` to `0.0.31`.